### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ Tento repositář obsahuje prototyp jednoduché webové aplikace pro správu kos
 - **PHP** (8+) – kvůli skriptu `upload.php`, který ukládá nahrané snímky
 
 Instalace Node.js i PHP je možná prostřednictvím oficiálních balíčků (např. `apt`, `brew` nebo instalátor z [nodejs.org](https://nodejs.org/) a [php.net](https://www.php.net/)).  Po instalaci
-spusťte `npm install` pro instalaci závislostí definovaných v `package.json`.
+spusťte `./setup.sh`. Skript ověří dostupnost Node.js a npm, případně nainstaluje závislosti a připraví adresáře `data/` a `fotky/`.
 
 ## Spuštění aplikace
 
 1. Naklonujte tento repositář a přejděte do jeho kořenového adresáře.
-2. Spusťte lokální PHP server (obslouží statické soubory i `upload.php`):
+2. Spusťte `./setup.sh` pro instalaci nebo aktualizaci závislostí.
+3. Spusťte lokální PHP server (obslouží statické soubory i `upload.php`):
 
    ```bash
    php -S localhost:8000
@@ -21,7 +22,7 @@ spusťte `npm install` pro instalaci závislostí definovaných v `package.json`
 
    Tím bude web dostupný na [http://localhost:8000](http://localhost:8000).
 
-3. (Volitelně) Pro vývoj React části spusťte:
+4. (Volitelně) Pro vývoj React části spusťte:
 
    ```bash
    npm start

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Setup script for the project
+
+# Function to check existence of a command
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Check for Node.js and npm
+if ! command_exists node; then
+    echo "Error: Node.js is not installed or not in PATH." >&2
+    exit 1
+fi
+
+if ! command_exists npm; then
+    echo "Error: npm is not installed or not in PATH." >&2
+    exit 1
+fi
+
+# Install npm dependencies if node_modules directory is missing
+if [ ! -d node_modules ]; then
+    echo "Installing npm dependencies..."
+    npm install
+fi
+
+# Create directories data and fotky if they do not exist
+for dir in data fotky; do
+    if [ ! -d "$dir" ]; then
+        echo "Creating directory $dir"
+        mkdir -p "$dir"
+    fi
+done
+
+echo "Setup completed." 


### PR DESCRIPTION
## Summary
- add new `setup.sh` to install dependencies and prepare directories
- document running `./setup.sh` in README

## Testing
- `./setup.sh` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_b_6861b9b683308322a8aa1e591114ad67